### PR TITLE
feat(ui,admin): standardize admin tables & add specialties carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>H&Q Hospital</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Onest:wght@100..900&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
+        "embla-carousel-autoplay": "^8.6.0",
+        "embla-carousel-react": "^8.6.0",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.544.0",
         "next-themes": "^0.4.6",
@@ -3817,6 +3819,43 @@
       "integrity": "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "embla-carousel-autoplay": "^8.6.0",
+    "embla-carousel-react": "^8.6.0",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.544.0",
     "next-themes": "^0.4.6",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import MedicalConsultationsPage from "./pages/consultations/MedicalConsultations
 import Forbidden from "@/pages/Forbidden.jsx"; // <-- tu página 403
 import { useAuth } from "@/hooks/use-auth";
 import AuthLayout from "@/layouts/AuthLayout.jsx";
+import SpecialtiesOfferPage from "@/pages/specialty/SpecialtiesOfferPage.jsx";
 
 function RoleBasedHome() {
     const { user } = useAuth();
@@ -60,6 +61,8 @@ export default function App() {
                                 <Route path="/patients" element={<PatientsPage />} />
                                 <Route path="/consultations" element={<MedicalConsultationsPage />} />
                                 <Route path="/consultations/form" element={<MedicalConsultationFormPage />} />
+
+                                <Route path="/specialties-offer" element={<SpecialtiesOfferPage />} />
                             </Route>
                         </Route>
                     </Route>

--- a/src/components/specialty/SpecialtiesCarousel.jsx
+++ b/src/components/specialty/SpecialtiesCarousel.jsx
@@ -1,0 +1,126 @@
+// src/components/SpecialtiesCarousel.jsx
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import specialties from "@/services/specialties.service";
+import {
+    Carousel,
+    CarouselContent,
+    CarouselItem,
+    CarouselNext,
+    CarouselPrevious,
+} from "@/components/ui/shadcn/carousel";
+import { Card } from "@/components/ui/shadcn/card";
+import Autoplay from "embla-carousel-autoplay";
+import { cn } from "@/lib/utils";
+
+function useAllSpecialties(includeDeleted = false) {
+    return useQuery({
+        queryKey: ["specialties-all", { includeDeleted }],
+        queryFn: () => specialties.listAllSpecialties({ includeDeleted }),
+        staleTime: 60_000,
+    });
+}
+
+// Helper: clamp sin plugin (3 líneas)
+const clamp = (lines) => ({
+    display: "-webkit-box",
+    WebkitLineClamp: lines,
+    WebkitBoxOrient: "vertical",
+    overflow: "hidden",
+    lineHeight: "1.25",
+    maxHeight: `calc(1.25em * ${lines})`, // fallback para navegadores sin -webkit-line-clamp
+    whiteSpace: "normal",
+    overflowWrap: "anywhere",
+    wordBreak: "break-word",
+});
+
+const Tile = ({ idx, name, description }) => (
+    <Card className="h-60 md:h-64 rounded-2xl border border-border/80 shadow-[0_6px_24px_-10px_rgb(0_0_0_/_.15)] hover:shadow-[0_10px_32px_-12px_rgb(0_0_0_/_.25)] transition-all overflow-hidden">
+        <div className="relative h-full flex flex-col p-4 md:p-5">
+            {/* Número grande (brand) */}
+            <span className="select-none absolute left-3 top-2 text-6xl md:text-7xl font-semibold leading-none text-brand opacity-25">
+        {String(idx).padStart(2, "0")}
+      </span>
+
+            {/* Título -> 1 línea con ellipsis */}
+            <h3 className="mt-6 md:mt-8 text-base font-semibold leading-tight truncate" title={name}>
+                {name}
+            </h3>
+
+            {/* Descripción -> máximo 3 líneas */}
+            <p
+                className="mt-3 text-sm text-muted-foreground leading-snug"
+                style={clamp(3)}
+                title={description || ""}
+            >
+                {description || "Sin descripción"}
+            </p>
+
+            {/* CTA anclado abajo */}
+            <div className="mt-auto pt-3">
+                <Link to="/consultations/form" className="text-primary underline underline-offset-2 font-medium">
+                    Agendar cita
+                </Link>
+            </div>
+        </div>
+    </Card>
+);
+
+export default function SpecialtiesCarousel({
+                                                className,
+                                                includeDeleted = false,
+                                                autoplay = true,
+                                            }) {
+    const { data, isLoading, isError } = useAllSpecialties(includeDeleted);
+    const plugin = React.useRef(Autoplay({ delay: 3500, stopOnInteraction: true }));
+
+    const list = React.useMemo(() => {
+        const items = Array.isArray(data) ? data : [];
+        return includeDeleted ? items : items.filter((s) => !s.deleted);
+    }, [data, includeDeleted]);
+
+    // Slides: ancho fijo por breakpoint (no crecen por contenido)
+    const itemClasses =
+        "shrink-0 grow-0 basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/3 xl:basis-1/4 min-w-[280px] md:min-w-[320px]";
+
+    return (
+        <div className={cn("w-full", className)}>
+            <Carousel opts={{ align: "start", loop: true }} plugins={autoplay ? [plugin.current] : []}>
+                <CarouselContent>
+                    {isLoading &&
+                        Array.from({ length: 6 }).map((_, i) => (
+                            <CarouselItem key={`sk-${i}`} className={itemClasses}>
+                                <div className="h-60 md:h-64 w-full animate-pulse rounded-2xl border" />
+                            </CarouselItem>
+                        ))}
+
+                    {!isLoading && !isError && list.length === 0 && (
+                        <CarouselItem className="basis-full shrink-0 grow-0">
+                            <Card className="h-60 grid place-items-center text-sm opacity-80">
+                                No hay especialidades para mostrar
+                            </Card>
+                        </CarouselItem>
+                    )}
+
+                    {!isLoading &&
+                        !isError &&
+                        list.map((s, i) => (
+                            <CarouselItem key={s.id} className={itemClasses}>
+                                <Tile idx={i + 1} name={s.name} description={s.description} />
+                            </CarouselItem>
+                        ))}
+                </CarouselContent>
+
+                <CarouselPrevious className="-left-3" />
+                <CarouselNext className="-right-3" />
+            </Carousel>
+
+            {isError && (
+                <div className="mt-3 text-sm text-destructive">
+                    Ocurrió un error al cargar las especialidades.
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/ui/shadcn/button.jsx
+++ b/src/components/ui/shadcn/button.jsx
@@ -1,54 +1,63 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
+// components/ui/shadcn/button.jsx
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
-
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+    [
+        "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md",
+        "text-sm font-medium",
+        "transition-all duration-200 ease-out transform-gpu will-change-transform",
+        "disabled:pointer-events-none disabled:opacity-50",
+        "[&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0",
+        "outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+    ].join(" "),
+    {
+        variants: {
+            variant: {
+                // ▶ Hover con OTRO color (brand-3) + elevación
+                default: [
+                    "bg-primary text-primary-foreground shadow-xs",
+                    "hover:bg-brand-3 active:bg-brand-2", // <-- color nuevo de hover/active
+                    "hover:-translate-y-[2px] active:translate-y-0 motion-reduce:transform-none",
+                    "hover:shadow-[0_14px_28px_-14px_color-mix(in_oklab,var(--brand-3),transparent_55%)]",
+                    "hover:ring-1 hover:ring-[color-mix(in_oklab,var(--brand-3),transparent_60%)]",
+                ].join(" "),
+                destructive:
+                    "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+                outline:
+                    "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+                secondary:
+                    "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+                ghost:
+                    "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+                link: "text-primary underline-offset-4 hover:underline",
+            },
+            size: {
+                default: "h-9 px-4 py-2 has-[>svg]:px-3",
+                sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+                lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+                icon: "size-9",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
+    }
+);
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}) {
-  const Comp = asChild ? Slot : "button"
-
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props} />
-  );
+function Button({ className, variant, size, asChild = false, ...props }) {
+    const Comp = asChild ? Slot : "button";
+    return (
+        <Comp
+            data-slot="button"
+            className={cn(buttonVariants({ variant, size }), className)}
+            {...props}
+        />
+    );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/shadcn/carousel.jsx
+++ b/src/components/ui/shadcn/carousel.jsx
@@ -1,0 +1,194 @@
+import * as React from "react"
+import useEmblaCarousel from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/shadcn/button"
+
+const CarouselContext = React.createContext(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+function Carousel({
+  orientation = "horizontal",
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}) {
+  const [carouselRef, api] = useEmblaCarousel({
+    ...opts,
+    axis: orientation === "horizontal" ? "x" : "y",
+  }, plugins)
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+  const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+  const onSelect = React.useCallback((api) => {
+    if (!api) return
+    setCanScrollPrev(api.canScrollPrev())
+    setCanScrollNext(api.canScrollNext())
+  }, [])
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext()
+  }, [api])
+
+  const handleKeyDown = React.useCallback((event) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault()
+      scrollPrev()
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault()
+      scrollNext()
+    }
+  }, [scrollPrev, scrollNext])
+
+  React.useEffect(() => {
+    if (!api || !setApi) return
+    setApi(api)
+  }, [api, setApi])
+
+  React.useEffect(() => {
+    if (!api) return
+    onSelect(api)
+    api.on("reInit", onSelect)
+    api.on("select", onSelect)
+
+    return () => {
+      api?.off("select", onSelect)
+    };
+  }, [api, onSelect])
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}>
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}>
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+}
+
+function CarouselContent({
+  className,
+  ...props
+}) {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      data-slot="carousel-content">
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props} />
+    </div>
+  );
+}
+
+function CarouselItem({
+  className,
+  ...props
+}) {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function CarouselPrevious({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn("absolute size-8 rounded-full", orientation === "horizontal"
+        ? "top-1/2 -left-12 -translate-y-1/2"
+        : "-top-12 left-1/2 -translate-x-1/2 rotate-90", className)}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}>
+      <ArrowLeft />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+}
+
+function CarouselNext({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn("absolute size-8 rounded-full", orientation === "horizontal"
+        ? "top-1/2 -right-12 -translate-y-1/2"
+        : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90", className)}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}>
+      <ArrowRight />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+}
+
+export { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext };

--- a/src/components/ui/typography/Heading.jsx
+++ b/src/components/ui/typography/Heading.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Separator } from "@/components/ui/shadcn/separator";
 import { Stars } from "lucide-react";
+import { useTheme } from "next-themes";
 
 export function PageHeading({
                                 title,
@@ -14,30 +15,52 @@ export function PageHeading({
                             }) {
     const LeadingIcon = Icon ?? TitleIcon;
 
+    // Tema actual (next-themes) – evita hydration mismatch
+    const { theme, systemTheme } = useTheme();
+    const [mounted, setMounted] = React.useState(false);
+    React.useEffect(() => setMounted(true), []);
+    const resolved = theme === "system" ? systemTheme : theme;
+    const isDark = mounted && resolved === "dark";
+
+    // Blobs: mezcla con tu velo mint (sin negros/blancos duros)
+    const veilPct = isDark ? 24 : 16;
+    const blobStyle = (brandVar) => ({
+        backgroundImage: `radial-gradient(closest-side,
+      color-mix(in oklab, var(${brandVar}), var(--brand-veil) ${veilPct}% ) 0%,
+      transparent 70%)`,
+        filter: isDark ? "saturate(110%) brightness(0.98)" : "saturate(110%)",
+    });
+
+    // Línea central petrol/teal que combina con tus mints
+    const petrolLight = "oklch(0.78 0.10 210)";
+    const petrolDark  = "oklch(0.84 0.09 210)";
+    const sepCore = isDark ? petrolDark : petrolLight;
+
+    // Bordes exteriores mint (ligeros)
+    const mintEdge = isDark
+        ? "linear-gradient(to right, transparent, color-mix(in oklab, var(--brand-1), transparent 60%), transparent)"
+        : "linear-gradient(to right, transparent, color-mix(in oklab, var(--brand-1), transparent 34%), transparent)";
+
     return (
         <div
             className={[
                 "relative w-full overflow-hidden hero-surface",
-                "px-6 py-10 sm:px-10 md:py-12 lg:px-14",
+                "px-6 py-6 sm:px-10 md:py-8 lg:px-14 xl:py-10",
                 "bg-hero-mint",
                 className,
             ].join(" ")}
         >
             <div className="liquid-pill" aria-hidden />
             <div className="pointer-events-none absolute inset-0 glass-edge" />
+
+            {/* Blobs mint suaves */}
             <div
                 className="pointer-events-none absolute -top-24 -left-24 h-80 w-80 rounded-full"
-                style={{
-                    backgroundImage:
-                        "radial-gradient(closest-side, color-mix(in oklab, var(--brand-2), white 30%) 0%, transparent 70%)",
-                }}
+                style={blobStyle("--brand-2")}
             />
             <div
                 className="pointer-events-none absolute -bottom-28 -right-28 h-96 w-96 rounded-full"
-                style={{
-                    backgroundImage:
-                        "radial-gradient(closest-side, color-mix(in oklab, var(--brand-3), white 30%) 0%, transparent 70%)",
-                }}
+                style={blobStyle("--brand-3")}
             />
 
             <div className="relative z-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
@@ -61,7 +84,7 @@ export function PageHeading({
                         ) : null}
 
                         <div className="flex items-center gap-3">
-                            <h1 className="text-3xl font-extrabold tracking-tight leading-tight md:text-4xl text-foreground">
+                            <h1 className="text-3xl font-semibold tracking-tight leading-tight md:text-4xl text-foreground">
                                 {title}
                             </h1>
                         </div>
@@ -77,10 +100,35 @@ export function PageHeading({
                 {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}
             </div>
 
-            {children ? <div className="relative z-10 mt-5">{children}</div> : null}
+            {/* ⬇️ Un pelín menos espacio antes del contenido secundario */}
+            {children ? <div className="relative z-10 mt-4">{children}</div> : null}
 
-            <div className="relative z-10 mt-6">
-                <Separator className="h-[1px] bg-gradient-to-r from-transparent via-[color-mix(in_oklab,var(--brand),transparent_70%)] to-transparent" />
+            {/* Separador: centro petrol/teal que resalta + doble borde mint exterior */}
+            {/* ⬇️ Menos espacio antes del separador */}
+            <div className="relative z-10 mt-4">
+                <div className="relative w-full">
+                    {/* Bordes mint exteriores */}
+                    <div
+                        aria-hidden
+                        className="pointer-events-none absolute inset-x-0 -top-px h-px"
+                        style={{ backgroundImage: mintEdge }}
+                    />
+                    <div
+                        aria-hidden
+                        className="pointer-events-none absolute inset-x-0 -bottom-px h-px"
+                        style={{ backgroundImage: mintEdge }}
+                    />
+
+                    {/* Línea central (petrol) */}
+                    <Separator
+                        className="relative h-[2px] rounded-full"
+                        style={{
+                            backgroundImage: `linear-gradient(to right, transparent, var(--sep-core), transparent)`,
+                            boxShadow: `0 0 10px color-mix(in oklab, var(--sep-core), transparent 88%)`,
+                            ["--sep-core"]: sepCore,
+                        }}
+                    />
+                </div>
             </div>
         </div>
     );

--- a/src/inc/admin/AdminBreadcrumbs.jsx
+++ b/src/inc/admin/AdminBreadcrumbs.jsx
@@ -15,6 +15,8 @@ const TITLE_MAP = {
     "labs": "Laboratorio",
     "centers": "Centros médicos",
     "history": "Historial",
+    "specialties": "Especialidades",
+    "employees": "Empleados",
     "starred": "Favoritos",
     "settings": "Ajustes",
     "playground": "Playground",

--- a/src/inc/admin/AdminSidebar.jsx
+++ b/src/inc/admin/AdminSidebar.jsx
@@ -46,262 +46,217 @@ function NavItem({ to, icon: Icon, label, className = "", end = false }) {
 
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton
-        asChild
-        tooltip={collapsed ? label : undefined}
-        className={`${
-          collapsed ? "justify-center px-0" : "justify-start"
-        } ${className}`}
-      >
-        <NavLink
-          to={to}
-          end={end}
-          aria-label={label}
-          className={[
-            "group",
-            collapsed
-              ? "relative w-full grid place-items-center rounded-lg px-0 py-0.5"
-              : "relative w-full flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-muted/60 text-foreground/90 aria-[current=page]:bg-accent aria-[current=page]:text-accent-foreground aria-[current=page]:ring-1 aria-[current=page]:ring-brand/20 aria-[current=page]:before:absolute aria-[current=page]:before:left-[-6px] aria-[current=page]:before:top-1/2 aria-[current=page]:before:-translate-y-1/2 aria-[current=page]:before:h-5 aria-[current=page]:before:w-[3px] aria-[current=page]:before:rounded-full aria-[current=page]:before:bg-brand",
-          ].join(" ")}
+        <SidebarMenuButton
+            asChild
+            tooltip={collapsed ? label : undefined}
+            className={`${collapsed ? "justify-center px-0" : "justify-start"} ${className}`}
         >
-          <span
-            className={[
+            <NavLink
+                to={to}
+                end={end}
+                aria-label={label}
+                className={[
+                    "group",
+                    collapsed
+                        ? "relative w-full grid place-items-center rounded-lg px-0 py-0.5"
+                        : "relative w-full flex items-center gap-2 rounded-lg px-2 py-2 hover:bg-muted/60 text-foreground/90 aria-[current=page]:bg-accent aria-[current=page]:text-accent-foreground aria-[current=page]:ring-1 aria-[current=page]:ring-brand/20 aria-[current=page]:before:absolute aria-[current=page]:before:left-[-6px] aria-[current=page]:before:top-1/2 aria-[current=page]:before:-translate-y-1/2 aria-[current=page]:before:h-5 aria-[current=page]:before:w-[3px] aria-[current=page]:before:rounded-full aria-[current=page]:before:bg-brand",
+                ].join(" ")}
+            >
+      <span
+          className={[
               collapsed
-                ? "grid size-7 place-content-center shrink-0 rounded-md mx-0 my-0"
-                : "grid size-7 place-content-center shrink-0 rounded-md",
+                  ? "grid size-7 place-content-center shrink-0 rounded-md mx-0 my-0"
+                  : "grid size-7 place-content-center shrink-0 rounded-md",
               "bg-transparent hover:bg-brand-1/25",
               collapsed
-                ? "group-aria-[current=page]:bg-accent group-aria-[current=page]:text-accent-foreground"
-                : "aria-[current=page]:bg-brand-1/40",
-            ].join(" ")}
-          >
-            <Icon
-              className={collapsed ? "size-3.5 shrink-0" : "size-4 shrink-0"}
-            />
-          </span>
-          {!collapsed && <span className="truncate">{label}</span>}
-        </NavLink>
-      </SidebarMenuButton>
+                  ? "group-aria-[current=page]:bg-accent group-aria-[current=page]:text-accent-foreground"
+                  : "aria-[current=page]:bg-brand-1/40",
+          ].join(" ")}
+      >
+        <Icon className={collapsed ? "size-3.5 shrink-0" : "size-4 shrink-0"} />
+      </span>
+                {!collapsed && <span className="truncate">{label}</span>}
+            </NavLink>
+        </SidebarMenuButton>
     </SidebarMenuItem>
-  );
+    );
 }
 
 const NAV_ADMIN_INICIO = [{ to: "/admin", icon: Heart, label: "Dashboard" }];
 
 const NAV_ADMIN_PLATAFORMA = [
-  { to: "/playground", icon: FolderKanban, label: "Playground" },
+    { to: "/playground", icon: FolderKanban, label: "Playground" },
 ];
 
 const NAV_ADMIN_GESTION = [
-  { to: "/employees", icon: UserCog, label: "Empleados" },
-  { to: "/doctors", icon: Stethoscope, label: "Doctores" },
-  { to: "/specialties", icon: ClipboardList, label: "Especialidades" },
-  { to: "/centers", icon: Building2, label: "Centros médicos" },
+    { to: "/employees", icon: UserCog, label: "Empleados" },
+    { to: "/doctors", icon: Stethoscope, label: "Doctores" },
+    { to: "/specialties", icon: ClipboardList, label: "Especialidades" },
+    { to: "/centers", icon: Building2, label: "Centros médicos" },
 ];
 
 const NAV_DOCTOR_GESTION = [
-  { to: "/patients", icon: UserRound, label: "Pacientes" },
-  { to: "/consultations", icon: ClipboardList, label: "Consultas médicas" },
+    { to: "/patients", icon: UserRound, label: "Pacientes" },
+    { to: "/consultations", icon: ClipboardList, label: "Consultas médicas" },
+    // ▼ NUEVO: página pública para ver/ofertar especialidades
+    { to: "/specialties-offer", icon: Stethoscope, label: "Especialidades" },
 ];
 
 const NAV_DOCS = [{ to: "/docs", icon: BookText, label: "Guías & Manuales" }];
 
 export default function AdminSidebar() {
-  const { state } = useSidebar();
-  const { user, logout } = useContext(AuthContext);
-  const collapsed = state === "collapsed";
-  const navigate = useNavigate();
+    const { state } = useSidebar();
+    const { user, logout } = useContext(AuthContext);
+    const collapsed = state === "collapsed";
+    const navigate = useNavigate();
 
-  const handleLogout = async () => {
-    await logout();
-    navigate("/login");
-  };
+    const handleLogout = async () => {
+        await logout();
+        navigate("/login");
+    };
 
-  return (
-    <Sidebar
-      collapsible="icon"
-      className="sidebar-surface border-r overflow-hidden"
-    >
-      <SidebarHeader
-        className={collapsed ? "px-4 pt-3 pb-3" : "px-4 pt-6 pb-4"}
-      >
-        <NavLink
-          to="/"
-          className={[
-            "group flex items-center gap-3 rounded-md outline-none",
-            "focus-visible:ring-2 focus-visible:ring-ring",
-            collapsed ? "justify-center px-0" : "",
-          ].join(" ")}
-        >
-          <div className="relative grid size-9 shrink-0 rounded-xl overflow-hidden border border-[color-mix(in_oklab,var(--brand-1),transparent_55%)] bg-[color-mix(in_oklab,var(--brand-veil),transparent_78%)] backdrop-blur-md">
-            <img
-              src={logoUrl}
-              alt="HQ"
-              className="w-full h-full object-contain"
-            />
-            <span
-              aria-hidden
-              className="absolute inset-0 rounded-xl pointer-events-none [background:conic-gradient(from_20deg_at_50%_50%,color-mix(in_oklab,var(--brand-1),transparent_85%),color-mix(in_oklab,var(--brand-2),transparent_88%),color-mix(in_oklab,var(--brand-3),transparent_85%),color-mix(in_oklab,#8ad2ff,transparent_90%),color-mix(in_oklab,#ffd38a,transparent_90%),color-mix(in_oklab,var(--brand-2),transparent_88%))] mix-blend-screen opacity-70 [padding:1px] [-webkit-mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] [mask-composite:exclude] [-webkit-mask-composite:xor]"
-            />
-          </div>
-          {!collapsed && (
-            <div className="leading-tight">
-              <p className="text-[1.05rem] font-semibold tracking-tight">
-                H<span className="text-sm relative -top-[1px]">&</span>Q
-                Hospital
-              </p>
-              <p className="text-[0.8rem] text-muted-foreground">
-                Administración
-              </p>
-            </div>
-          )}
-        </NavLink>
-      </SidebarHeader>
-
-      <SidebarContent
-        className={collapsed ? "px-1 overflow-hidden" : "px-2 overflow-hidden"}
-      >
-        <Can allowedRoles={["ADMIN"]}>
-          <SidebarGroup>
-            <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>
-              Inicio
-            </SidebarGroupLabel>
-            <SidebarGroupContent className="overflow-hidden">
-              <SidebarMenu>
-                {NAV_ADMIN_INICIO.map((item) => (
-                  <NavItem key={item.to} {...item} />
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-          <SidebarSeparator className="sidebar-divider my-2" />
-        </Can>
-
-        <Can allowedRoles={["ADMIN"]}>
-          <SidebarGroup>
-            <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>
-              Plataforma
-            </SidebarGroupLabel>
-            <SidebarGroupContent className="overflow-hidden">
-              <SidebarMenu>
-                {NAV_ADMIN_PLATAFORMA.map((item) => (
-                  <NavItem key={item.to} {...item} />
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-          <SidebarSeparator className="sidebar-divider my-2" />
-        </Can>
-
-        <SidebarGroup>
-          <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>
-            Gestión clínica
-          </SidebarGroupLabel>
-          <SidebarGroupContent className="overflow-hidden">
-            <SidebarMenu>
-              <Can allowedRoles={["ADMIN"]}>
-                {NAV_ADMIN_GESTION.map((item) => (
-                  <NavItem key={item.to} {...item} />
-                ))}
-              </Can>
-              <Can allowedRoles={["DOCTOR"]}>
-                {NAV_DOCTOR_GESTION.map((item) => (
-                  <NavItem key={item.to} {...item} />
-                ))}
-              </Can>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-
-        <SidebarSeparator className="sidebar-divider my-2" />
-
-        <SidebarGroup>
-          <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>
-            Documentación
-          </SidebarGroupLabel>
-          <SidebarGroupContent className="overflow-hidden">
-            <SidebarMenu>
-              {NAV_DOCS.map((item) => (
-                <NavItem key={item.to} {...item} />
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-
-      <SidebarFooter
-        className={
-          collapsed
-            ? "mt-auto border-t px-2 pt-2 pb-1"
-            : "mt-auto border-t px-3 py-3"
-        }
-      >
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <SidebarMenuButton
-                  asChild
-                  tooltip={collapsed ? "Cuenta" : undefined}
-                  className={
-                    collapsed ? "justify-center px-0" : "justify-start"
-                  }
+    return (
+        <Sidebar collapsible="icon" className="sidebar-surface border-r overflow-hidden">
+            <SidebarHeader className={collapsed ? "px-4 pt-3 pb-3" : "px-4 pt-6 pb-4"}>
+                <NavLink
+                    to="/"
+                    className={[
+                        "group flex items-center gap-3 rounded-md outline-none",
+                        "focus-visible:ring-2 focus-visible:ring-ring",
+                        collapsed ? "justify-center px-0" : "",
+                    ].join(" ")}
                 >
-                  <button
-                    type="button"
-                    className={
-                      collapsed
-                        ? "h-9 w-9 grid place-items-center rounded-md"
-                        : "w-full cursor-pointer"
-                    }
-                    aria-label="Cuenta"
-                  >
-                    <Avatar
-                      className={
-                        collapsed ? "size-7 shrink-0" : "size-8 shrink-0"
-                      }
-                    >
-                      <AvatarImage
-                        src="https://i.pravatar.cc/64?img=3"
-                        alt="@user"
-                      />
-                      <AvatarFallback>
-                        {user ? user.first_name[0] + user.last_name[0] : "U"}
-                      </AvatarFallback>
-                    </Avatar>
-
+                    <div className="relative grid size-9 shrink-0 rounded-xl overflow-hidden border border-[color-mix(in_oklab,var(--brand-1),transparent_55%)] bg-[color-mix(in_oklab,var(--brand-veil),transparent_78%)] backdrop-blur-md">
+                        <img src={logoUrl} alt="HQ" className="w-full h-full object-contain" />
+                        <span
+                            aria-hidden
+                            className="absolute inset-0 rounded-xl pointer-events-none [background:conic-gradient(from_20deg_at_50%_50%,color-mix(in_oklab,var(--brand-1),transparent_85%),color-mix(in_oklab,var(--brand-2),transparent_88%),color-mix(in_oklab,var(--brand-3),transparent_85%),color-mix(in_oklab,#8ad2ff,transparent_90%),color-mix(in_oklab,#ffd38a,transparent_90%),color-mix(in_oklab,var(--brand-2),transparent_88%))] mix-blend-screen opacity-70 [padding:1px] [-webkit-mask:linear-gradient(#000_0_0)_content-box,linear-gradient(#000_0_0)] [mask-composite:exclude] [-webkit-mask-composite:xor]"
+                        />
+                    </div>
                     {!collapsed && (
-                      <div className="grid grow truncate text-left ml-2">
+                        <div className="leading-tight">
+                            <p className="text-[1.05rem] font-semibold tracking-tight">
+                                H<span className="text-sm relative -top-[1px]">&</span>Q Hospital
+                            </p>
+                            <p className="text-[0.8rem] text-muted-foreground">Administración</p>
+                        </div>
+                    )}
+                </NavLink>
+            </SidebarHeader>
+
+            <SidebarContent className={collapsed ? "px-1 overflow-hidden" : "px-2 overflow-hidden"}>
+                {/* INICIO */}
+                <Can allowedRoles={["ADMIN"]}>
+                    <SidebarGroup>
+                        <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>Inicio</SidebarGroupLabel>
+                        <SidebarGroupContent className="overflow-hidden">
+                            <SidebarMenu>
+                                {NAV_ADMIN_INICIO.map((item) => (
+                                    <NavItem key={item.to} {...item} />
+                                ))}
+                            </SidebarMenu>
+                        </SidebarGroupContent>
+                    </SidebarGroup>
+                    <SidebarSeparator className="sidebar-divider my-2" />
+                </Can>
+
+                {/* GESTIÓN CLÍNICA */}
+                <SidebarGroup>
+                    <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>Gestión clínica</SidebarGroupLabel>
+                    <SidebarGroupContent className="overflow-hidden">
+                        <SidebarMenu>
+                            <Can allowedRoles={["ADMIN"]}>
+                                {NAV_ADMIN_GESTION.map((item) => (
+                                    <NavItem key={item.to} {...item} />
+                                ))}
+                            </Can>
+                            <Can allowedRoles={["DOCTOR"]}>
+                                {NAV_DOCTOR_GESTION.map((item) => (
+                                    <NavItem key={item.to} {...item} />
+                                ))}
+                            </Can>
+                        </SidebarMenu>
+                    </SidebarGroupContent>
+                </SidebarGroup>
+
+                {/* ▼ MOVIDO: PLAYGROUND debajo de Gestión clínica */}
+                <SidebarSeparator className="sidebar-divider my-2" />
+                <Can allowedRoles={["ADMIN"]}>
+                    <SidebarGroup>
+                        <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>Plataforma</SidebarGroupLabel>
+                        <SidebarGroupContent className="overflow-hidden">
+                            <SidebarMenu>
+                                {NAV_ADMIN_PLATAFORMA.map((item) => (
+                                    <NavItem key={item.to} {...item} />
+                                ))}
+                            </SidebarMenu>
+                        </SidebarGroupContent>
+                    </SidebarGroup>
+                    <SidebarSeparator className="sidebar-divider my-2" />
+                </Can>
+
+                {/* DOCUMENTACIÓN */}
+                <SidebarGroup>
+                    <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>Documentación</SidebarGroupLabel>
+                    <SidebarGroupContent className="overflow-hidden">
+                        <SidebarMenu>
+                            {NAV_DOCS.map((item) => (
+                                <NavItem key={item.to} {...item} />
+                            ))}
+                        </SidebarMenu>
+                    </SidebarGroupContent>
+                </SidebarGroup>
+            </SidebarContent>
+
+            <SidebarFooter className={collapsed ? "mt-auto border-t px-2 pt-2 pb-1" : "mt-auto border-t px-3 py-3"}>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <SidebarMenuButton
+                                    asChild
+                                    tooltip={collapsed ? "Cuenta" : undefined}
+                                    className={collapsed ? "justify-center px-0" : "justify-start"}
+                                >
+                                    <button
+                                        type="button"
+                                        className={collapsed ? "h-9 w-9 grid place-items-center rounded-md" : "w-full cursor-pointer"}
+                                        aria-label="Cuenta"
+                                    >
+                                        <Avatar className={collapsed ? "size-7 shrink-0" : "size-8 shrink-0"}>
+                                            <AvatarImage src="https://i.pravatar.cc/64?img=3" alt="@user" />
+                                            <AvatarFallback>
+                                                {user ? user.first_name[0] + user.last_name[0] : "U"}
+                                            </AvatarFallback>
+                                        </Avatar>
+
+                                        {!collapsed && (
+                                            <div className="grid grow truncate text-left ml-2">
                         <span className="truncate text-sm font-medium">
-                          {user
-                            ? `${user.first_name} ${user.last_name}`
-                            : "Usuario"}
+                          {user ? `${user.first_name} ${user.last_name}` : "Usuario"}
                         </span>
-                        <span className="truncate text-xs text-muted-foreground">
+                                                <span className="truncate text-xs text-muted-foreground">
                           {user?.email ?? "sin correo"}
                         </span>
-                      </div>
-                    )}
-                  </button>
-                </SidebarMenuButton>
-              </DropdownMenuTrigger>
+                                            </div>
+                                        )}
+                                    </button>
+                                </SidebarMenuButton>
+                            </DropdownMenuTrigger>
 
-              <DropdownMenuContent align="end" side="top" className="w-48">
-                <DropdownMenuItem disabled>
-                  {user ? `${user.first_name} ${user.last_name}` : "Usuario"}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={handleLogout}
-                  className="text-red-600 focus:bg-red-100"
-                >
-                  Cerrar sesión
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarFooter>
-    </Sidebar>
-  );
+                            <DropdownMenuContent align="end" side="top" className="w-48">
+                                <DropdownMenuItem disabled>
+                                    {user ? `${user.first_name} ${user.last_name}` : "Usuario"}
+                                </DropdownMenuItem>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuItem onClick={handleLogout} className="text-red-600 focus:bg-red-100">
+                                    Cerrar sesión
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarFooter>
+        </Sidebar>
+    );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@import url('https://fonts.googleapis.com/css2?family=Onest:wght@100..900&display=swap');
+
 @custom-variant dark (&:is(.dark *));
 
 :root{
@@ -37,6 +39,9 @@
     --muted-foreground:oklch(.52 0 0);
     --destructive:oklch(.62 .18 27);
 
+    --primary-hover: color-mix(in oklab, var(--brand-2), white 10%);
+    --primary-active: color-mix(in oklab, var(--brand-3), black 6%);
+
     /* Charts opcional */
     --chart-1:oklch(.80 .07 200);
     --chart-2:oklch(.78 .07 160);
@@ -53,6 +58,13 @@
     --sidebar-accent-foreground:oklch(.205 0 0);
     --sidebar-border:oklch(.92 0 0);
     --sidebar-ring:var(--ring);
+}
+
+@theme {
+    --font-sans: "Onest", ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, "Noto Sans", "Helvetica Neue",
+    Arial, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 @theme inline{
@@ -125,6 +137,9 @@
     --muted-foreground:oklch(.72 0 0);
     --destructive:oklch(.62 .18 27);
 
+    --primary-hover: color-mix(in oklab, var(--brand-2), black 10%);
+    --primary-active: color-mix(in oklab, var(--brand-3), black 16%);
+
     --sidebar:oklch(.20 0 0);
     --sidebar-foreground:oklch(.985 0 0);
     --sidebar-primary:var(--primary);
@@ -142,7 +157,7 @@
 @layer base{
     *{@apply border-border outline-ring/50}
     html,body,#root{height:100%}
-    body{@apply bg-background text-foreground antialiased}
+    body{@apply bg-background text-foreground antialiased font-sans}
 }
 
 #root{max-width:none!important;margin:0!important;padding:0!important;text-align:unset!important}

--- a/src/pages/admin/DoctorPage.jsx
+++ b/src/pages/admin/DoctorPage.jsx
@@ -56,16 +56,15 @@ const baseColumns = (onEdit, onDelete) => [
         header: "Especialidad",
         cell: ({ row }) => row.original.specialtyName || "—",
     },
-    // NUEVO: Estado calculado desde `deleted`
     {
-        id: "status",
+        accessorKey: "deleted",
         header: "Estado",
         cell: ({ row }) => {
             const isDeleted = !!row.original.deleted;
             return (
                 <span className={isDeleted ? "text-red-600 font-medium" : "text-green-600 font-medium"}>
-          {isDeleted ? "Inactivo" : "Activo"}
-        </span>
+                  {isDeleted ? "Inactivo" : "Activo"}
+                </span>
             );
         },
     },
@@ -225,7 +224,26 @@ export default function DoctorsPage() {
 
             <Card className="overflow-hidden">
                 <CardHeader className="pb-2">
-                    <CardTitle>Doctores</CardTitle>
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <CardTitle className="text-base">Doctores</CardTitle>
+                            <p className="mt-1 text-sm text-muted-foreground">
+                                Listado administrativo de profesionales
+                            </p>
+                        </div>
+
+                        {/* Leyenda de estados */}
+                        <div className="hidden sm:flex items-center gap-3 text-xs text-muted-foreground">
+                          <span className="inline-flex items-center gap-1">
+                            <span className="size-2 rounded-full bg-green-500" />
+                            Activo
+                          </span>
+                                                <span className="inline-flex items-center gap-1">
+                            <span className="size-2 rounded-full bg-red-500" />
+                            Inactivo
+                          </span>
+                        </div>
+                    </div>
                 </CardHeader>
 
                 <CardContent>

--- a/src/pages/admin/MedicalCentersPage.jsx
+++ b/src/pages/admin/MedicalCentersPage.jsx
@@ -53,14 +53,14 @@ const columns = (onEdit, onDelete) => [
         ),
     },
     {
-        id: "status",
+        accessorKey: "deleted",
         header: "Estado",
         cell: ({ row }) => {
             const isDeleted = !!row.original.deleted;
             return (
                 <span className={isDeleted ? "text-red-600 font-medium" : "text-green-600 font-medium"}>
-          {isDeleted ? "Inactivo" : "Activo"}
-        </span>
+                  {isDeleted ? "Inactivo" : "Activo"}
+                </span>
             );
         },
     },
@@ -304,7 +304,24 @@ export default function MedicalCentersPage() {
 
             {/* Tabla */}
             <div className="rounded-xl border bg-card">
-                <div className="p-4">
+                <div className="flex items-center justify-between px-6 pt-6 pb-2">
+                    <div>
+                        <h3 className="text-base font-semibold text-foreground">Centros médicos</h3>
+                        <p className="text-sm text-muted-foreground">Directorio administrativo de centros</p>
+                    </div>
+                    <div className="hidden sm:flex items-center gap-3 text-sm text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
+                        <span className="size-2 rounded-full bg-green-500" />
+                        Activo
+                      </span>
+                                        <span className="inline-flex items-center gap-1">
+                        <span className="size-2 rounded-full bg-red-500" />
+                        Inactivo
+                      </span>
+                    </div>
+                </div>
+
+                <div className="p-6 pt-6 pb-4">
                     <DataTable
                         columns={columns(onEdit, onDelete)}
                         data={rows}
@@ -314,11 +331,11 @@ export default function MedicalCentersPage() {
                         state={{ pagination: { pageIndex: page, pageSize } }}
                         onPaginationChange={handlePaginationChange}
                         emptyMessage={isLoading ? "Cargando..." : error ? error : "Sin datos"}
-                        searchable={false} // sin buscador global ni filtros
+                        searchable={false}
                     />
                 </div>
 
-                <div className="flex items-center justify-between px-4 py-2 text-sm text-muted-foreground">
+                <div className="flex items-center justify-between px-4 py-2 text-[0.95rem] text-muted-foreground">
                     <div>
                         Total: {totalElements}
                         <Separator

--- a/src/pages/admin/SpecialtiesPage.jsx
+++ b/src/pages/admin/SpecialtiesPage.jsx
@@ -47,14 +47,14 @@ const columns = (onEdit, onDelete) => [
         ),
     },
     {
-        id: "status",
+        accessorKey: "deleted",
         header: "Estado",
         cell: ({ row }) => {
             const isDeleted = !!row.original.deleted;
             return (
                 <span className={isDeleted ? "text-red-600 font-medium" : "text-green-600 font-medium"}>
-          {isDeleted ? "Inactivo" : "Activo"}
-        </span>
+                  {isDeleted ? "Inactivo" : "Activo"}
+                </span>
             );
         },
     },
@@ -280,9 +280,25 @@ export default function SpecialtiesPage() {
                 }
             />
 
-            {/* Contenedor igual al ejemplo */}
             <div className="rounded-xl border bg-card">
-                <div className="p-4">
+                <div className="flex items-center justify-between px-6 pt-6 pb-2">
+                    <div>
+                        <h3 className="text-base font-semibold text-foreground">Especialidades</h3>
+                        <p className="text-sm text-muted-foreground">Catálogo administrativo de especialidades médicas</p>
+                    </div>
+                    <div className="hidden sm:flex items-center gap-3 text-sm text-muted-foreground">
+                      <span className="inline-flex items-center gap-1">
+                        <span className="size-2 rounded-full bg-green-500" />
+                        Activa
+                      </span>
+                                        <span className="inline-flex items-center gap-1">
+                        <span className="size-2 rounded-full bg-red-500" />
+                        Inactiva
+                      </span>
+                    </div>
+                </div>
+
+                <div className="p-6 pt-6 pb-4">
                     <DataTable
                         columns={columns(onEdit, onDelete)}
                         data={rows}
@@ -296,13 +312,10 @@ export default function SpecialtiesPage() {
                     />
                 </div>
 
-                <div className="flex items-center justify-between px-4 py-2 text-sm text-muted-foreground">
+                <div className="flex items-center justify-between px-4 py-2 text-[0.95rem] text-muted-foreground">
                     <div>
                         Total: {total}
-                        <Separator
-                            className="mx-3 h-4 inline-block align-middle"
-                            orientation="vertical"
-                        />
+                        <Separator className="mx-3 h-4 inline-block align-middle" orientation="vertical" />
                         Página {pageIndex + 1} de {Math.max(pageCount, 1)}
                     </div>
                     <Button

--- a/src/pages/consultations/MedicalConsultationsPage.jsx
+++ b/src/pages/consultations/MedicalConsultationsPage.jsx
@@ -2,222 +2,233 @@ import React, { useState, useCallback } from "react";
 import { getUserCenterId, getUserId } from "@/utils/auth";
 import { useDoctorByUser } from "@/hooks/useDoctors";
 import {
-  useMedicalConsultationsPage,
-  useDeleteMedicalConsultation,
+    useMedicalConsultationsPage,
+    useDeleteMedicalConsultation,
 } from "@/hooks/useConsultations";
 import { Button } from "@/components/ui/shadcn/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogFooter,
 } from "@/components/ui/shadcn/dialog";
 import DataTable from "@/components/ui/table/data-table-pb";
-import { Plus, Pencil, Trash2, Eye } from "lucide-react";
+import { Plus, Pencil, Trash2, Eye, ClipboardList } from "lucide-react";
 import { PageHeading } from "@/components/ui/typography/Heading";
 import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
 import { useCenter } from "@/hooks/useMedicalCenters";
 
 export default function MedicalConsultationsPage() {
-  const navigate = useNavigate();
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(5);
+    const navigate = useNavigate();
+    const [page, setPage] = useState(0);
+    const [pageSize, setPageSize] = useState(5);
 
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [consultationToDelete, setConsultationToDelete] = useState(null);
+    const [confirmOpen, setConfirmOpen] = useState(false);
+    const [consultationToDelete, setConsultationToDelete] = useState(null);
 
-  const userId = getUserId();
-  const { data: doctorData } = useDoctorByUser(userId);
-  const doctorId = doctorData?.data?.id;
-  const centerId = getUserCenterId();
+    const userId = getUserId();
+    const { data: doctorData } = useDoctorByUser(userId);
+    const doctorId = doctorData?.data?.id;
+    const centerId = getUserCenterId();
 
-  const { data, isLoading, refetch } = useMedicalConsultationsPage({
-    doctorId,
-    page,
-    size: pageSize,
-  });
+    const { data, isLoading, refetch } = useMedicalConsultationsPage({
+        doctorId,
+        page,
+        size: pageSize,
+    });
 
-  const { data: centerData } = useCenter(centerId);
-  const centers = centerData ? [centerData.data] : [];
-  const consultations = data?.content ?? [];
-  const totalPages = data?.totalPages ?? 1;
-  const totalRows = data?.totalElements ?? 0;
+    const { data: centerData } = useCenter(centerId);
+    const centers = centerData ? [centerData.data] : []; // (si lo usas luego)
+    const consultations = data?.content ?? [];
+    const totalPages = data?.totalPages ?? 1;
+    const totalRows = data?.totalElements ?? 0;
 
-  const deleteMut = useDeleteMedicalConsultation();
+    const deleteMut = useDeleteMedicalConsultation();
 
-  const resetModalStates = useCallback(() => {
-    setConsultationToDelete(null);
-  }, []);
+    const resetModalStates = useCallback(() => {
+        setConsultationToDelete(null);
+    }, []);
 
-  const truncateText = (text, maxLength = 20) => {
-    if (!text) return "";
-    return text.length > maxLength ? text.substring(0, maxLength) + "…" : text;
-  };
+    const truncateText = (text, maxLength = 20) => {
+        if (!text) return "";
+        return text.length > maxLength ? text.substring(0, maxLength) + "…" : text;
+    };
 
-  const columns = [
-    { accessorKey: "id", header: "ID", cell: ({ row }) => row.original.id },
-    {
-      accessorKey: "patient",
-      header: "Paciente",
-      cell: ({ row }) =>
-        `${row.original.patient.firstName} ${row.original.patient.lastName}`,
-    },
-    {
-      accessorKey: "date",
-      header: "Fecha",
-      cell: ({ row }) =>
-        new Date(row.original.date).toLocaleDateString("es-EC"),
-    },
-    {
-      accessorKey: "diagnosis",
-      header: "Diagnóstico",
-      cell: ({ row }) => truncateText(row.original.diagnosis),
-    },
-    {
-      accessorKey: "treatment",
-      header: "Tratamiento",
-      cell: ({ row }) => truncateText(row.original.treatment),
-    },
-    {
-      accessorKey: "notes",
-      header: "Notas",
-      cell: ({ row }) => truncateText(row.original.notes),
-    },
-  ];
+    const columns = [
+        { accessorKey: "id", header: "ID", cell: ({ row }) => row.original.id },
+        {
+            accessorKey: "patient",
+            header: "Paciente",
+            cell: ({ row }) =>
+                `${row.original.patient.firstName} ${row.original.patient.lastName}`,
+        },
+        {
+            accessorKey: "date",
+            header: "Fecha",
+            cell: ({ row }) =>
+                new Date(row.original.date).toLocaleDateString("es-EC"),
+        },
+        {
+            accessorKey: "diagnosis",
+            header: "Diagnóstico",
+            cell: ({ row }) => truncateText(row.original.diagnosis),
+        },
+        {
+            accessorKey: "treatment",
+            header: "Tratamiento",
+            cell: ({ row }) => truncateText(row.original.treatment),
+        },
+        {
+            accessorKey: "notes",
+            header: "Notas",
+            cell: ({ row }) => truncateText(row.original.notes),
+        },
+    ];
 
-  const rowActions = (row) => {
-    const consultation = row.original;
-    return (
-      <div className="flex gap-1 justify-end">
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() =>
-            navigate("/consultations/form", {
-              state: { consultationId: consultation.id, mode: "view" },
-            })
-          }
-          title="Ver"
-        >
-          <Eye className="size-4" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() =>
-            navigate("/consultations/form", {
-              state: { consultationId: consultation.id, mode: "edit" },
-            })
-          }
-          title="Editar"
-        >
-          <Pencil className="size-4" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() => {
-            setConsultationToDelete(consultation);
-            setConfirmOpen(true);
-          }}
-          title="Eliminar"
-        >
-          <Trash2 className="size-4 text-destructive" />
-        </Button>
-      </div>
-    );
-  };
+    const rowActions = (row) => {
+        const consultation = row.original;
+        return (
+            <div className="flex gap-1 justify-end">
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() =>
+                        navigate("/consultations/form", {
+                            state: { consultationId: consultation.id, mode: "view" },
+                        })
+                    }
+                    title="Ver"
+                >
+                    <Eye className="size-4" />
+                </Button>
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() =>
+                        navigate("/consultations/form", {
+                            state: { consultationId: consultation.id, mode: "edit" },
+                        })
+                    }
+                    title="Editar"
+                >
+                    <Pencil className="size-4" />
+                </Button>
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => {
+                        setConsultationToDelete(consultation);
+                        setConfirmOpen(true);
+                    }}
+                    title="Eliminar"
+                >
+                    <Trash2 className="size-4 text-destructive" />
+                </Button>
+            </div>
+        );
+    };
 
-  const handlePaginationChange = ({ pageIndex, pageSize: newPageSize }) => {
-    if (pageIndex !== page || newPageSize !== pageSize) {
-      setPage(pageIndex);
-      setPageSize(newPageSize);
-    }
-  };
-
-  return (
-    <div className="space-y-6 p-6">
-      <PageHeading
-        title="Consultas Médicas"
-        subtitle="Crea, edita y administra consultas médicas"
-        actions={
-          <Button
-            onClick={() =>
-              navigate("/consultations/form", { state: { mode: "create" } })
-            }
-          >
-            <Plus className="mr-2 size-4" />
-            Nueva consulta
-          </Button>
+    const handlePaginationChange = ({ pageIndex, pageSize: newPageSize }) => {
+        if (pageIndex !== page || newPageSize !== pageSize) {
+            setPage(pageIndex);
+            setPageSize(newPageSize);
         }
-      />
+    };
 
-      <DataTable
-        columns={columns}
-        data={consultations}
-        rowActions={rowActions}
-        manualPagination={true}
-        pageCount={totalPages}
-        totalRows={totalRows}
-        state={{
-          pagination: {
-            pageIndex: page,
-            pageSize: pageSize,
-          },
-        }}
-        onPaginationChange={handlePaginationChange}
-        emptyMessage="Sin datos"
-        searchable={false}
-        loading={isLoading}
-      />
-
-      {/* Modal Confirmar Eliminación */}
-      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogContent className="max-w-md w-full">
-          <DialogHeader>
-            <DialogTitle>Confirmar eliminación</DialogTitle>
-          </DialogHeader>
-          {consultationToDelete && (
-            <p className="py-4">
-              ¿Eliminar la consulta del paciente{" "}
-              <strong>
-                {consultationToDelete.patient.firstName}{" "}
-                {consultationToDelete.patient.lastName}
-              </strong>{" "}
-              con fecha{" "}
-              <strong>
-                {new Date(consultationToDelete.date).toLocaleDateString("es-EC")}
-              </strong>
-              ?
-            </p>
-          )}
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setConfirmOpen(false)}>
-              Cancelar
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={async () => {
-                try {
-                  await deleteMut.mutateAsync(consultationToDelete.id);
-                  toast.success("Consulta médica eliminada");
-                  setConfirmOpen(false);
-                  resetModalStates();
-                  refetch();
-                } catch (e) {
-                  toast.error(
-                    e?.data?.detail || "Error al eliminar la consulta médica"
-                  );
+    return (
+        <div className="space-y-6 p-6">
+            <PageHeading
+                title="Consultas Médicas"
+                subtitle="Registra cada atención con precisión, y asegura una atención continua y confiable."
+                icon={ClipboardList}
+                actions={
+                    <Button
+                        onClick={() =>
+                            navigate("/consultations/form", { state: { mode: "create" } })
+                        }
+                    >
+                        <Plus className="mr-2 size-4" />
+                        Nueva consulta
+                    </Button>
                 }
-              }}
-            >
-              Eliminar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
-  );
+            />
+
+            {/* Contenido en CARD: subtítulo + tabla (sin secciones) */}
+            <div className="rounded-xl border bg-card">
+                {/* Subtítulo tipo label */}
+                <div className="px-4 pt-3">
+                    <p className="text-sm font-medium text-muted-foreground">
+                        Listado de consultas
+                    </p>
+                </div>
+
+                {/* Tabla */}
+                <div className="p-4 pt-1">
+                    <DataTable
+                        columns={columns}
+                        data={consultations}
+                        rowActions={rowActions}
+                        manualPagination={true}
+                        pageCount={totalPages}
+                        totalRows={totalRows}
+                        state={{ pagination: { pageIndex: page, pageSize: pageSize } }}
+                        onPaginationChange={handlePaginationChange}
+                        emptyMessage="Sin datos"
+                        searchable={false}
+                        loading={isLoading}
+                    />
+                </div>
+            </div>
+
+            {/* Modal Confirmar Eliminación */}
+            <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                <DialogContent className="max-w-md w-full">
+                    <DialogHeader>
+                        <DialogTitle>Confirmar eliminación</DialogTitle>
+                    </DialogHeader>
+                    {consultationToDelete && (
+                        <p className="py-4">
+                            ¿Eliminar la consulta del paciente{" "}
+                            <strong>
+                                {consultationToDelete.patient.firstName}{" "}
+                                {consultationToDelete.patient.lastName}
+                            </strong>{" "}
+                            con fecha{" "}
+                            <strong>
+                                {new Date(consultationToDelete.date).toLocaleDateString(
+                                    "es-EC"
+                                )}
+                            </strong>
+                            ?
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setConfirmOpen(false)}>
+                            Cancelar
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={async () => {
+                                try {
+                                    await deleteMut.mutateAsync(consultationToDelete.id);
+                                    toast.success("Consulta médica eliminada");
+                                    setConfirmOpen(false);
+                                    resetModalStates();
+                                    refetch();
+                                } catch (e) {
+                                    toast.error(
+                                        e?.data?.detail || "Error al eliminar la consulta médica"
+                                    );
+                                }
+                            }}
+                        >
+                            Eliminar
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
 }

--- a/src/pages/employees/EmployeePage.jsx
+++ b/src/pages/employees/EmployeePage.jsx
@@ -180,38 +180,51 @@ export default function EmployeesPage() {
       />
 
       <div className="rounded-xl border bg-card">
-        <div className="p-4">
-          <DataTable
-            columns={columns(handleDelete)}
-            data={rows}
-            manualPagination={true}
-            pageCount={Math.max(totalPages, 1)}
-            totalRows={totalElements}
-            state={{ pagination: { pageIndex: page, pageSize } }}
-            onPaginationChange={handlePaginationChange}
-            emptyMessage={
-              isLoading ? "Cargando..." : error ? error : "Sin datos"
-            }
-            searchable={false}
-          />
-        </div>
+          <div className="rounded-xl border bg-card">
+              <div className="flex items-center justify-between px-6 pt-6 pb-2">
+                  <div>
+                      <h3 className="text-base font-semibold text-foreground">Empleados</h3>
+                      <p className="text-sm text-muted-foreground">Directorio administrativo del personal</p>
+                  </div>
+                  <div className="hidden sm:flex items-center gap-3 text-sm text-muted-foreground">
+      <span className="inline-flex items-center gap-1">
+        <span className="size-2 rounded-full bg-green-500" />
+        Activo
+      </span>
+                      <span className="inline-flex items-center gap-1">
+        <span className="size-2 rounded-full bg-red-500" />
+        Inactivo
+      </span>
+                  </div>
+              </div>
 
-        <div className="flex items-center justify-between px-4 py-2 text-sm text-muted-foreground">
-          <div>
-            Total: {totalElements}
-            <Separator
-              className="mx-3 h-4 inline-block align-middle"
-              orientation="vertical"
-            />
-            Página {page + 1} de {Math.max(totalPages, 1)}
+              <div className="p-6 pt-6 pb-4">
+                  <DataTable
+                      columns={columns(handleDelete)}
+                      data={rows}
+                      manualPagination={true}
+                      pageCount={Math.max(totalPages, 1)}
+                      totalRows={totalElements}
+                      state={{ pagination: { pageIndex: page, pageSize } }}
+                      onPaginationChange={handlePaginationChange}
+                      emptyMessage={isLoading ? "Cargando..." : error ? error : "Sin datos"}
+                      searchable={false}
+                  />
+              </div>
+
+              <div className="flex items-center justify-between px-4 py-2 text-[0.95rem] text-muted-foreground">
+                  <div>
+                      Total: {totalElements}
+                      <Separator className="mx-3 h-4 inline-block align-middle" orientation="vertical" />
+                      Página {page + 1} de {Math.max(totalPages, 1)}
+                  </div>
+                  <Button variant="ghost" size="sm" onClick={load} disabled={isLoading}>
+                      {isLoading ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                      Refrescar
+                  </Button>
+              </div>
           </div>
-          <Button variant="ghost" size="sm" onClick={load} disabled={isLoading}>
-            {isLoading ? (
-              <Loader2 className="mr-2 size-4 animate-spin" />
-            ) : null}
-            Refrescar
-          </Button>
-        </div>
+
       </div>
     </div>
   );

--- a/src/pages/patients/PatientsPage.jsx
+++ b/src/pages/patients/PatientsPage.jsx
@@ -1,283 +1,289 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback } from "react";
 import { useCenter } from "@/hooks/useMedicalCenters";
 import { Button } from "@/components/ui/shadcn/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogFooter,
 } from "@/components/ui/shadcn/dialog";
 import DataTable from "@/components/ui/table/data-table-pb";
 import PatientForm from "@/components/patients/PatientForm";
 import PatientReadOnly from "@/components/patients/PatientReadOnly";
 import { PageHeading } from "@/components/ui/typography/Heading";
-import { Plus, Pencil, Trash2, Eye } from "lucide-react";
+import { Plus, Pencil, Trash2, Eye, UserRound } from "lucide-react";
 import { toast } from "sonner";
 import {
-  usePatientsPage,
-  useCreatePatient,
-  useUpdatePatient,
-  useDeletePatient,
+    usePatientsPage,
+    useCreatePatient,
+    useUpdatePatient,
+    useDeletePatient,
 } from "@/hooks/usePatient";
 import { getUserCenterId } from "@/utils/auth";
 
 export default function PatientsPage() {
-  const [formOpen, setFormOpen] = useState(false);
-  const [viewOpen, setViewOpen] = useState(false);
-  const [editForm, setEditForm] = useState({});
-  const [selectedPatient, setSelectedPatient] = useState(null);
-  const [serverErrors, setServerErrors] = useState({});
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(5);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [patientToDelete, setPatientToDelete] = useState(null);
+    const [formOpen, setFormOpen] = useState(false);
+    const [viewOpen, setViewOpen] = useState(false);
+    const [editForm, setEditForm] = useState({});
+    const [selectedPatient, setSelectedPatient] = useState(null);
+    const [serverErrors, setServerErrors] = useState({});
+    const [page, setPage] = useState(0);
+    const [pageSize, setPageSize] = useState(5);
+    const [confirmOpen, setConfirmOpen] = useState(false);
+    const [patientToDelete, setPatientToDelete] = useState(null);
 
-  const centerId = getUserCenterId();
+    const centerId = getUserCenterId();
 
+    const { data, isLoading, isError, error, refetch } = usePatientsPage({
+        centerId,
+        page,
+        size: pageSize,
+    });
 
-  const { data, isLoading, isError, error, refetch } = usePatientsPage({
-    centerId,
-    page,
-    size: pageSize,
-  });
+    const { data: centerData } = useCenter(centerId);
+    const centers = centerData ? [centerData.data] : [];
+    const patientsList = data?.content ?? [];
+    const totalPages = data?.totalPages ?? 1;
+    const totalElements = data?.totalElements ?? 0;
 
-  const { data: centerData } = useCenter(centerId);
-  const centers = centerData ? [centerData.data] : [];
-  const patientsList = data?.content ?? [];
-  const totalPages = data?.totalPages ?? 1;
-  const totalElements = data?.totalElements ?? 0;
+    const createMut = useCreatePatient();
+    const updateMut = useUpdatePatient(editForm.id);
+    const deleteMut = useDeletePatient();
 
-  const createMut = useCreatePatient();
-  const updateMut = useUpdatePatient(editForm.id);
-  const deleteMut = useDeletePatient();
+    const resetModalStates = useCallback(() => {
+        setEditForm({});
+        setSelectedPatient(null);
+        setServerErrors({});
+        setPatientToDelete(null);
+    }, []);
 
-  const resetModalStates = useCallback(() => {
-    setEditForm({});
-    setSelectedPatient(null);
-    setServerErrors({});
-    setPatientToDelete(null);
-  }, []);
+    const columns = [
+        { accessorKey: "id", header: "ID" },
+        { accessorKey: "dni", header: "DNI" },
+        { accessorKey: "firstName", header: "Nombre" },
+        { accessorKey: "lastName", header: "Apellido" },
+        {
+            accessorKey: "gender",
+            header: "Género",
+            cell: ({ row }) =>
+                row.original.gender === "FEMALE"
+                    ? "Femenino"
+                    : row.original.gender === "MALE"
+                        ? "Masculino"
+                        : "Otro",
+        },
+        {
+            accessorKey: "birthDate",
+            header: "Nacimiento",
+            cell: ({ row }) =>
+                row.original.birthDate
+                    ? new Date(row.original.birthDate).toLocaleDateString("es-EC")
+                    : "",
+        },
+        {
+            accessorKey: "centerId",
+            header: "Centro",
+            cell: () => centerData?.data?.name ?? "—",
+        },
+    ];
 
-  const columns = [
-    { accessorKey: "id", header: "ID" },
-    { accessorKey: "dni", header: "DNI" },
-    { accessorKey: "firstName", header: "Nombre" },
-    { accessorKey: "lastName", header: "Apellido" },
-    {
-      accessorKey: "gender",
-      header: "Género",
-      cell: ({ row }) =>
-        row.original.gender === "FEMALE"
-          ? "Femenino"
-          : row.original.gender === "MALE"
-          ? "Masculino"
-          : "Otro",
-    },
-    {
-      accessorKey: "birthDate",
-      header: "Nacimiento",
-      cell: ({ row }) =>
-        row.original.birthDate
-          ? new Date(row.original.birthDate).toLocaleDateString("es-EC")
-          : "",
-    },
-    {
-      accessorKey: "centerId",
-      header: "Centro",
-      cell: () => centerData?.data?.name ?? "—",
-    },
-  ];
+    const rowActions = (row) => {
+        const p = row.original;
+        return (
+            <div className="flex gap-1 justify-end">
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => {
+                        setSelectedPatient(p);
+                        setViewOpen(true);
+                    }}
+                    title="Ver"
+                >
+                    <Eye className="size-4" />
+                </Button>
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => {
+                        setEditForm(p);
+                        setFormOpen(true);
+                    }}
+                    title="Editar"
+                >
+                    <Pencil className="size-4" />
+                </Button>
+                <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => {
+                        setPatientToDelete(p);
+                        setConfirmOpen(true);
+                    }}
+                    title="Eliminar"
+                >
+                    <Trash2 className="size-4 text-destructive" />
+                </Button>
+            </div>
+        );
+    };
 
-  const rowActions = (row) => {
-    const p = row.original;
-    return (
-      <div className="flex gap-1 justify-end">
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() => {
-            setSelectedPatient(p);
-            setViewOpen(true);
-          }}
-          title="Ver"
-        >
-          <Eye className="size-4" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() => {
-            setEditForm(p);
-            setFormOpen(true);
-          }}
-          title="Editar"
-        >
-          <Pencil className="size-4" />
-        </Button>
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={() => {
-            setPatientToDelete(p);
-            setConfirmOpen(true);
-          }}
-          title="Eliminar"
-        >
-          <Trash2 className="size-4 text-destructive" />
-        </Button>
-      </div>
-    );
-  };
-
-  const handlePaginationChange = ({ pageIndex, pageSize: newPageSize }) => {
-    // Solo actualizar los valores si han cambiado
-    if (pageIndex !== page || newPageSize !== pageSize) {
-      setPage(pageIndex);
-      setPageSize(newPageSize);
-      // El refetch se ejecutará automáticamente cuando cambien page o pageSize
-      // gracias a las dependencias del hook usePatientsPage
-    }
-  };
-
-  const handleSave = async (data) => {
-    try {
-      console.log(data);
-      setServerErrors({});
-      if (editForm.id) {
-        await updateMut.mutateAsync(data);
-        toast.success("Paciente actualizado");
-      } else {
-        await createMut.mutateAsync(data);
-        toast.success("Paciente creado");
-      }
-      setFormOpen(false);
-      resetModalStates();
-      refetch();
-    } catch (e) {
-      setServerErrors(e?.data?.errors ?? {});
-      toast.error(e?.data?.detail || "Error");
-    }
-  };
-
-  return (
-    <div className="space-y-6 p-6">
-      <PageHeading
-        title="Pacientes"
-        subtitle="Crea, edita y administra pacientes"
-        actions={
-          <Button
-            onClick={() => {
-              resetModalStates();
-              setFormOpen(true);
-            }}
-          >
-            <Plus className="mr-2 size-4" />
-            Nuevo paciente
-          </Button>
+    const handlePaginationChange = ({ pageIndex, pageSize: newPageSize }) => {
+        if (pageIndex !== page || newPageSize !== pageSize) {
+            setPage(pageIndex);
+            setPageSize(newPageSize);
         }
-      />
+    };
 
-      {isLoading ? (
-        <div>Cargando pacientes...</div>
-      ) : isError ? (
-        <div className="text-red-500">{error.message}</div>
-      ) : (
-        <DataTable
-          columns={columns}
-          data={patientsList}
-          rowActions={rowActions}
-          manualPagination={true}
-          pageCount={totalPages}
-          totalRows={totalElements}
-          state={{
-            pagination: {
-              pageIndex: page,
-              pageSize: pageSize,
-            },
-          }}
-          onPaginationChange={handlePaginationChange}
-          emptyMessage="Sin datos"
-          searchable={false} // Desactivar búsqueda local ya que es paginación del servidor
-        />
-      )}
+    const handleSave = async (payload) => {
+        try {
+            setServerErrors({});
+            if (editForm.id) {
+                await updateMut.mutateAsync(payload);
+                toast.success("Paciente actualizado");
+            } else {
+                await createMut.mutateAsync(payload);
+                toast.success("Paciente creado");
+            }
+            setFormOpen(false);
+            resetModalStates();
+            refetch();
+        } catch (e) {
+            setServerErrors(e?.data?.errors ?? {});
+            toast.error(e?.data?.detail || "Error");
+        }
+    };
 
-      {/* Modal Crear/Editar */}
-      <Dialog
-        open={formOpen}
-        onOpenChange={(o) => {
-          if (!o) resetModalStates();
-          setFormOpen(o);
-        }}
-      >
-        <DialogContent className="max-w-lg w-full">
-          <DialogHeader>
-            <DialogTitle>
-              {editForm.id ? "Editar paciente" : "Nuevo paciente"}
-            </DialogTitle>
-          </DialogHeader>
-          <PatientForm
-            defaultValues={editForm}
-            onSubmit={handleSave}
-            centers={centers}
-            serverErrors={serverErrors}
-            formId="patient-form"
-          />
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setFormOpen(false)}>
-              Cancelar
-            </Button>
-            <Button type="submit" form="patient-form">
-              Guardar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+    return (
+        <div className="space-y-6 p-6">
+            <PageHeading
+                title="Pacientes Clínicos"
+                subtitle="Crea nuevos registros, modificalos y mantén los datos siempre actualizados."
+                icon={UserRound}
+                actions={
+                    <Button
+                        onClick={() => {
+                            resetModalStates();
+                            setFormOpen(true);
+                        }}
+                    >
+                        <Plus className="mr-2 size-4" />
+                        Nuevo paciente
+                    </Button>
+                }
+            />
 
-      {/* Modal Ver */}
-      <Dialog open={viewOpen} onOpenChange={setViewOpen}>
-        <DialogContent className="max-w-lg w-full">
-          <DialogHeader>
-            <DialogTitle>Ver paciente</DialogTitle>
-          </DialogHeader>
-          <PatientReadOnly patient={selectedPatient} centers={centers} />
-          <DialogFooter>
-            <Button onClick={() => setViewOpen(false)}>Cerrar</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            {/* Contenido en CARD: subtítulo + tabla (sin dividir en secciones) */}
+            <div className="rounded-xl border bg-card">
+                <div className="px-4 pt-3">
+                    <p className="text-sm font-medium text-muted-foreground">
+                        Listado de pacientes
+                    </p>
+                </div>
 
-      {/* Modal Confirmar Eliminación */}
-      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogContent className="max-w-md w-full">
-          <DialogHeader>
-            <DialogTitle>Confirmar eliminación</DialogTitle>
-          </DialogHeader>
-          {patientToDelete && (
-            <p className="py-4">
-              ¿Eliminar a {patientToDelete.firstName} {patientToDelete.lastName}
-              ?
-            </p>
-          )}
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setConfirmOpen(false)}>
-              Cancelar
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={async () => {
-                await deleteMut.mutateAsync(patientToDelete.id);
-                toast.success("Paciente eliminado");
-                setConfirmOpen(false);
-                resetModalStates();
-                refetch();
-              }}
+                <div className="p-4 pt-1">
+                    {isLoading ? (
+                        <div className="text-sm text-muted-foreground">Cargando pacientes…</div>
+                    ) : isError ? (
+                        <div className="text-sm text-destructive">{error?.message || "Error al cargar"}</div>
+                    ) : (
+                        <DataTable
+                            columns={columns}
+                            data={patientsList}
+                            rowActions={rowActions}
+                            manualPagination={true}
+                            pageCount={totalPages}
+                            totalRows={totalElements}
+                            state={{
+                                pagination: {
+                                    pageIndex: page,
+                                    pageSize: pageSize,
+                                },
+                            }}
+                            onPaginationChange={handlePaginationChange}
+                            emptyMessage="Sin datos"
+                            searchable={false}
+                        />
+                    )}
+                </div>
+            </div>
+
+            {/* Modal Crear/Editar */}
+            <Dialog
+                open={formOpen}
+                onOpenChange={(o) => {
+                    if (!o) resetModalStates();
+                    setFormOpen(o);
+                }}
             >
-              Eliminar
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
-  );
+                <DialogContent className="max-w-lg w-full">
+                    <DialogHeader>
+                        <DialogTitle>
+                            {editForm.id ? "Editar paciente" : "Nuevo paciente"}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <PatientForm
+                        defaultValues={editForm}
+                        onSubmit={handleSave}
+                        centers={centers}
+                        serverErrors={serverErrors}
+                        formId="patient-form"
+                    />
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setFormOpen(false)}>
+                            Cancelar
+                        </Button>
+                        <Button type="submit" form="patient-form">
+                            Guardar
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Modal Ver */}
+            <Dialog open={viewOpen} onOpenChange={setViewOpen}>
+                <DialogContent className="max-w-lg w-full">
+                    <DialogHeader>
+                        <DialogTitle>Ver paciente</DialogTitle>
+                    </DialogHeader>
+                    <PatientReadOnly patient={selectedPatient} centers={centers} />
+                    <DialogFooter>
+                        <Button onClick={() => setViewOpen(false)}>Cerrar</Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Modal Confirmar Eliminación */}
+            <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                <DialogContent className="max-w-md w-full">
+                    <DialogHeader>
+                        <DialogTitle>Confirmar eliminación</DialogTitle>
+                    </DialogHeader>
+                    {patientToDelete && (
+                        <p className="py-4">
+                            ¿Eliminar a {patientToDelete.firstName} {patientToDelete.lastName}?
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setConfirmOpen(false)}>
+                            Cancelar
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={async () => {
+                                await deleteMut.mutateAsync(patientToDelete.id);
+                                toast.success("Paciente eliminado");
+                                setConfirmOpen(false);
+                                resetModalStates();
+                                refetch();
+                            }}
+                        >
+                            Eliminar
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
 }

--- a/src/pages/specialty/SpecialtiesOfferPage.jsx
+++ b/src/pages/specialty/SpecialtiesOfferPage.jsx
@@ -1,0 +1,138 @@
+// src/pages/specialty/SpecialtiesOfferPage.jsx
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+
+import { PageHeading } from "@/components/ui/typography/Heading";
+import { Button } from "@/components/ui/shadcn/button";
+import { Separator } from "@/components/ui/shadcn/separator";
+import { Card } from "@/components/ui/shadcn/card";
+import { Stethoscope, LayoutGrid, PanelsTopLeft } from "lucide-react";
+
+import specialties from "@/services/specialties.service";
+import SpecialtiesCarousel from "@/components/specialty/SpecialtiesCarousel";
+
+// clamp sin plugin (corta a N líneas sin crecer la tarjeta)
+const clamp = (lines) => ({
+    display: "-webkit-box",
+    WebkitLineClamp: lines,
+    WebkitBoxOrient: "vertical",
+    overflow: "hidden",
+    lineHeight: "1.25",
+    maxHeight: `calc(1.25em * ${lines})`,
+    whiteSpace: "normal",
+    overflowWrap: "anywhere",
+    wordBreak: "break-word",
+});
+
+// tarjeta reutilizable para el modo GRID
+function SpecialtyTile({ idx, name, description }) {
+    return (
+        <Card className="h-60 md:h-64 rounded-2xl border border-border/80 shadow-[0_6px_24px_-10px_rgb(0_0_0_/_.15)] hover:shadow-[0_10px_32px_-12px_rgb(0_0_0_/_.25)] transition-all overflow-hidden">
+            <div className="relative h-full flex flex-col p-4 md:p-5">
+        <span className="select-none absolute left-3 top-2 text-6xl md:text-7xl font-semibold leading-none text-brand opacity-25">
+          {String(idx).padStart(2, "0")}
+        </span>
+
+                <h3 className="mt-6 md:mt-8 text-base font-semibold leading-tight truncate" title={name}>
+                    {name}
+                </h3>
+
+                <p className="mt-3 text-sm text-muted-foreground leading-snug" style={clamp(3)} title={description || ""}>
+                    {description || "Sin descripción"}
+                </p>
+
+                <div className="mt-auto pt-3">
+                    <Link to="/consultations/form" className="text-primary underline underline-offset-2 font-medium">
+                        Agendar cita
+                    </Link>
+                </div>
+            </div>
+        </Card>
+    );
+}
+
+export default function SpecialtiesOfferPage() {
+    const [view, setView] = React.useState("carousel"); // "carousel" | "grid"
+
+    // Datos para el modo GRID (usamos la misma fuente que el carrusel)
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ["specialties-all", { includeDeleted: false }],
+        queryFn: () => specialties.listAllSpecialties({ includeDeleted: false }),
+        staleTime: 60_000,
+    });
+
+    const list = React.useMemo(() => {
+        const items = Array.isArray(data) ? data : [];
+        return items.filter((s) => !s.deleted);
+    }, [data]);
+
+    const toggleView = () => setView((v) => (v === "carousel" ? "grid" : "carousel"));
+
+    return (
+        <div className="space-y-6 p-6">
+            <PageHeading
+                title="Especialidades"
+                subtitle="Explora y selecciona una especialidad."
+                icon={Stethoscope}
+                actions={
+                    <Button variant="outline" onClick={toggleView}>
+                        {view === "carousel" ? (
+                            <>
+                                <LayoutGrid className="mr-2 size-4" />
+                                Ver todo
+                            </>
+                        ) : (
+                            <>
+                                <PanelsTopLeft className="mr-2 size-4" />
+                                Ver carrusel
+                            </>
+                        )}
+                    </Button>
+                }
+            />
+
+            {/* Contenedor (card) del contenido principal */}
+            <div className="mx-auto max-w-7xl -mt-2 md:-mt-3">
+                <div className="rounded-xl border bg-card shadow-sm">
+                    {/* Header de la card */}
+                    <div className="flex items-center justify-between px-4 py-3">
+                        <h2 className="text-xl font-semibold">Explora por especialidad</h2>
+                        <span className="text-sm text-muted-foreground">
+              {view === "carousel" ? "Desliza para ver más" : `Total: ${list.length}`}
+            </span>
+                    </div>
+
+                    <Separator />
+
+                    {/* Contenido según vista */}
+                    <div className="p-10">
+                        {view === "carousel" ? (
+                            <SpecialtiesCarousel autoplay perView={{ base: 1, sm: 2, md: 3, lg: 3, xl: 4 }} />
+                        ) : (
+                            <>
+                                {isLoading && (
+                                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4">
+                                        {Array.from({ length: 8 }).map((_, i) => (
+                                            <div key={i} className="h-60 md:h-64 rounded-2xl border animate-pulse" />
+                                        ))}
+                                    </div>
+                                )}
+
+                                {isError && <div className="text-sm text-destructive">No se pudieron cargar las especialidades.</div>}
+
+                                {!isLoading && !isError && (
+                                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4">
+                                        {list.map((s, i) => (
+                                            <SpecialtyTile key={s.id} idx={i + 1} name={s.name} description={s.description} />
+                                        ))}
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
- Introduce unified DataTable wrapper (sorting, pagination, toolbar).
- Wrap all admin tables in a consistent Card: • header title + helper text • larger typography & spacing • footer with totals, page info and refresh action
- Apply to: Specialties, Doctors, Employees, Medical Centers, Patients and Medical Consultations pages.
- Fix: enable client-side column sorting on Doctors table (Status, etc.).
- Add SpecialtiesCarousel (Embla + shadcn) and doctor-only SpecialtiesOfferPage with min card width, brand-tinted index number, and line-clamp for long names/descriptions; “Book appointment” links to /consultations/form.
- Sidebar: expose Specialties (doctor) and position Playground correctly.
- Polish: stronger primary button hover with lift animation; small visual tweaks (index.css tokens, headings).

No breaking changes.